### PR TITLE
Fix bug in Runbook tab listview double-click

### DIFF
--- a/AutomationISE/AutomationISEControl.xaml.cs
+++ b/AutomationISE/AutomationISEControl.xaml.cs
@@ -879,7 +879,7 @@ namespace AutomationISE
                     AutomationRunbook selectedRunbook = (AutomationRunbook)obj;
                     if (selectedRunbook.SyncStatus == AutomationRunbook.Constants.SyncStatus.CloudOnly)
                     {
-                        MessageBox.Show("There is no local copy of " + selectedRunbook.localFileInfo.Name + " to open.",
+                        MessageBox.Show("There is no local copy of the selected runbook to open. Please download the runbook.",
                                 "No Local Runbook", MessageBoxButton.OK, MessageBoxImage.Warning);
                         continue;
                     }


### PR DESCRIPTION
In the Runbook tab when an entry that has not been downloaded is double-clicked, an error is returned instead of the desired warning message box. This is because an un-synced runbook does not return the localFileInfo property.
