### PR TITLE
Foreign langage issue #122 Bug Fix

### DIFF
--- a/AutomationISE/AutomationISEControl.xaml.cs
+++ b/AutomationISE/AutomationISEControl.xaml.cs
@@ -666,7 +666,7 @@ namespace AutomationISE
                     /* Change current directory to new workspace location */
                     accountPathTextBox.Text = iseClient.currWorkspace;
                     string pathHint = Path.GetPathRoot(iseClient.currWorkspace) + "..." + Path.DirectorySeparatorChar + Path.GetFileName(iseClient.currWorkspace);
-                    HostObject.CurrentPowerShellTab.Invoke("cd '" + iseClient.currWorkspace + "'" + ";function prompt {'PS " + pathHint + "> '}");
+                    HostObject.CurrentPowerShellTab.Invoke("cd \"" + iseClient.currWorkspace + "\"" + ";function prompt {'PS " + pathHint + "> '}");
                     promptShortened = true;
                     endBackgroundWork("Finished getting data for " + account.Name);
                     refreshAccountDataTimer.Start();

--- a/AutomationISE/AutomationISEControl.xaml.cs
+++ b/AutomationISE/AutomationISEControl.xaml.cs
@@ -2044,14 +2044,14 @@ namespace AutomationISE
             {
                 if (promptShortened)
                 {
-                    HostObject.CurrentPowerShellTab.Invoke("cd '" + iseClient.currWorkspace + "'" + ";function prompt {'PS ' + $(Get-Location) + '> '}");
+                    HostObject.CurrentPowerShellTab.Invoke("cd \"" + iseClient.currWorkspace + "\"" + ";function prompt {'PS ' + $(Get-Location) + '> '}");
                     promptShortened = false;
                 }
                 else
                 {
                     //TODO: factor this into the iseClient
                     string pathHint = Path.GetPathRoot(iseClient.currWorkspace) + "..." + Path.DirectorySeparatorChar + Path.GetFileName(iseClient.currWorkspace);
-                    HostObject.CurrentPowerShellTab.Invoke("cd '" + iseClient.currWorkspace + "'" + ";function prompt {'PS " + pathHint + "> '}");
+                    HostObject.CurrentPowerShellTab.Invoke("cd \"" + iseClient.currWorkspace + "\"" + ";function prompt {'PS " + pathHint + "> '}");
                     promptShortened = true;
                 }
             }


### PR DESCRIPTION
Switched to using double quotes for change directory commands so that apostrophes and single quotes will not terminate the path string.
