### PR TITLE
Fixing logon when conditional access makes logon fail

### DIFF
--- a/AutomationISE/Model/AutomationISEClient.cs
+++ b/AutomationISE/Model/AutomationISEClient.cs
@@ -76,18 +76,29 @@ namespace AutomationISE.Model
             // Get subscriptions for each tenant
             foreach (var tenant in tenants.TenantIds)
             {
-                AuthenticationResult tenantTokenCreds = AuthenticateHelper.RefreshTokenByAuthority(tenant.TenantId, Properties.Settings.Default.appIdURI);
-                subscriptionCredentials = new Microsoft.Azure.TokenCloudCredentials(tenantTokenCreds.AccessToken);
-                var tenantSubscriptionClient = new Microsoft.Azure.Subscriptions.SubscriptionClient(subscriptionCredentials,new Uri(Properties.Settings.Default.appIdURI));
-                var subscriptionListResults = tenantSubscriptionClient.Subscriptions.ListAsync(cancelToken).Result;
-
-                foreach (var subscription in subscriptionListResults.Subscriptions)
+                try
                 {
-                    var subList = new SubscriptionObject();
-                    subList.Name = subscription.DisplayName;
-                    subList.SubscriptionId = subscription.SubscriptionId;
-                    subList.Authority = tenant.TenantId;
-                    subscriptionList.Add(subList);
+                    AuthenticationResult tenantTokenCreds =
+                        AuthenticateHelper.RefreshTokenByAuthority(tenant.TenantId,
+                            Properties.Settings.Default.appIdURI);
+                    subscriptionCredentials = new Microsoft.Azure.TokenCloudCredentials(tenantTokenCreds.AccessToken);
+                    var tenantSubscriptionClient =
+                        new Microsoft.Azure.Subscriptions.SubscriptionClient(subscriptionCredentials,
+                            new Uri(Properties.Settings.Default.appIdURI));
+                    var subscriptionListResults = tenantSubscriptionClient.Subscriptions.ListAsync(cancelToken).Result;
+
+                    foreach (var subscription in subscriptionListResults.Subscriptions)
+                    {
+                        var subList = new SubscriptionObject();
+                        subList.Name = subscription.DisplayName;
+                        subList.SubscriptionId = subscription.SubscriptionId;
+                        subList.Authority = tenant.TenantId;
+                        subscriptionList.Add(subList);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // ignored
                 }
             }
 


### PR DESCRIPTION
Hey!

I have access to multiple customers Azure AD using my main account.
One of my customer decided to add conditional access to their subscription.

This makes it impossible for me to use the Add-in, as the error message pops up and afterwards the logon procedure is "user cancelled logon"

This is the error I am talking about:
![image](https://user-images.githubusercontent.com/3460807/35924989-d550acf4-0c24-11e8-979f-a5d5264b9d91.png)

To fix it, I have made a change in the client so that it skips any failed ADs.
it might not be the best way, you might know a better way to do it, but this does work.
Error still pops up but logon procedure does not fail.
