### PR TITLE
Update AzureAutomationAuthoringToolkitInner.psm1

### DIFF
--- a/AzureAutomationAuthoringToolkit/AzureAutomationAuthoringToolkitInner.psm1
+++ b/AzureAutomationAuthoringToolkit/AzureAutomationAuthoringToolkitInner.psm1
@@ -392,7 +392,9 @@ function Get-AzureAutomationAuthoringToolkitConfiguration {
     if(!($Configuration.LocalAssetsPath -and $Configuration.SecureLocalAssetsPath -and $Configuration.EncryptionCertificateThumbprint)) {
         throw $ConfigurationError
     }
-
+    ## Replace hiphen issue
+    $Configuration.LocalAssetsPath = $Configuration.LocalAssetsPath.Replace('â€“','–')
+    $Configuration.SecureLocalAssetsPath = $Configuration.SecureLocalAssetsPath.Replace('â€“','–')    
     Write-Output $Configuration
 }
 


### PR DESCRIPTION
Hiphen issue, issue raised for more details

If an Azure subscription name contains a Hyphen that acts as a word connector. It breaks the import process:
Ahmad – Abdalla (Not OK)
Ahmad - Abdalla (OK).


Hyphen Issue when importing assets #150